### PR TITLE
Correct the typo, should be options

### DIFF
--- a/lib/snapshot_tree/acts_as_tree.rb
+++ b/lib/snapshot_tree/acts_as_tree.rb
@@ -66,7 +66,7 @@ module SnapshotTree
           dependent:   options[:dependent]
 
         has_many :child_tree_nodes,
-          -> { where(optoins[:is_active_field].to_sym => true) if options[:is_active_field] },
+          -> { where(options[:is_active_field].to_sym => true) if options[:is_active_field] },
           class_name:  options[:join_class],
           foreign_key: options[:parent_key],
           autosave:    true,


### PR DESCRIPTION
Try to fix the typo, which leads to the unexpected error when try calling `destroy`
![Screen Shot 2022-01-05 at 10 57 30 PM](https://user-images.githubusercontent.com/12430486/148238673-c2e3715e-035d-42f2-9729-1ab447b85a3d.png)
 